### PR TITLE
Add support for Spring Boot JARs

### DIFF
--- a/examples/rapid-store/client-java/pom.xml
+++ b/examples/rapid-store/client-java/pom.xml
@@ -10,13 +10,13 @@
     <parent>
         <groupId>com.github.packleader.rapid.store</groupId>
         <artifactId>rapid-store-service-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <com.github.packleader.rapid.version>1.0.1-SNAPSHOT</com.github.packleader.rapid.version>
+        <com.github.packleader.rapid.version>1.0.2-SNAPSHOT</com.github.packleader.rapid.version>
         <com.fasterxml.jackson.version>2.9.7</com.fasterxml.jackson.version>
         <org.springframework.version>5.2.3.RELEASE</org.springframework.version>
     </properties>
@@ -65,8 +65,8 @@
     </build>
 
     <dependencies>
-        <!-- Required dependency on the RAPID Store service artifact -->
-        <!-- Update this dependency to reference an artifact containing your service's class files.  The artifact must be a JAR. -->
+        <!-- Required dependency on the RAPID Store service artifact.  The artifact must be a JAR and may be a SpringBoot JAR. -->
+        <!-- Update this dependency to reference an artifact containing your service's class files. -->
         <dependency>
             <groupId>com.github.packleader.rapid.store</groupId>
             <artifactId>rapid-store-service</artifactId>

--- a/examples/rapid-store/pom.xml
+++ b/examples/rapid-store/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.github.packleader.rapid.store</groupId>
     <artifactId>rapid-store-service-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <name>${project.artifactId}</name>
 
     <modules>

--- a/examples/rapid-store/service/pom.xml
+++ b/examples/rapid-store/service/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.github.packleader.rapid.store</groupId>
         <artifactId>rapid-store-service-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.2-SNAPSHOT</version>
     </parent>
 
     <properties>
@@ -60,6 +60,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${org.springframework.boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.packleader.rapid</groupId>
     <artifactId>rapid-client-integration-maven-plugin</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
     <description>A maven build plugin to generate APIs for interfacing with RESTful services.</description>
     <url>https://github.com/packleader/rapid-client-integration</url>
@@ -33,6 +33,7 @@
         <org.apache.commons.version>2.6.0</org.apache.commons.version>
         <org.testng.version>7.1.0</org.testng.version>
         <org.powermock.version>2.0.5</org.powermock.version>
+        <org.javassist.version>3.25.0-GA</org.javassist.version>
     </properties>
 
     <dependencies>
@@ -114,6 +115,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>${org.javassist.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/plugin/src/main/java/com/packleader/rapid/plugin/RapidComponentConfigurator.java
+++ b/plugin/src/main/java/com/packleader/rapid/plugin/RapidComponentConfigurator.java
@@ -1,6 +1,5 @@
 package com.packleader.rapid.plugin;
 
-
 import com.github.kongchen.swagger.docgen.mavenplugin.IncludeProjectDependenciesComponentConfigurator;
 import org.apache.maven.model.Resource;
 import org.codehaus.classworlds.ClassRealm;

--- a/plugin/src/main/java/com/packleader/rapid/plugin/RapidDependencyHelper.java
+++ b/plugin/src/main/java/com/packleader/rapid/plugin/RapidDependencyHelper.java
@@ -1,0 +1,63 @@
+package com.packleader.rapid.plugin;
+
+import lombok.SneakyThrows;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.codehaus.plexus.classworlds.realm.DuplicateRealmException;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+
+@Component(role = RapidDependencyHelper.class)
+public class RapidDependencyHelper {
+
+    @Requirement
+    private MavenProject mavenProject;
+
+    @Requirement
+    private ZipFileHelper zipFileHelper;
+
+    private static final String CHARSET = StandardCharsets.UTF_8.name();
+    private static final String SPRING_BOOT_PREFIX = "BOOT-INF/classes/";
+
+    @SneakyThrows
+    public void unpackDependencies() {
+        File destDir = new File( mavenProject.getBuild().getDirectory() + "/unpacked-dependencies");
+
+        unpackDependencies(mavenProject.getCompileClasspathElements(), destDir);
+
+        File classDir = new File(destDir, SPRING_BOOT_PREFIX);
+        addToClassLoader(classDir);
+    }
+
+    private void unpackDependencies(Collection<String> dependencies, File destDir) throws IOException {
+        for(String dependency : dependencies) {
+            dependency = URLDecoder.decode(dependency, CHARSET);
+            File dependencyFile = new File(dependency);
+            if(dependencyFile.isFile()) {
+                zipFileHelper.unpack(dependencyFile, destDir, e -> e.getName().startsWith(SPRING_BOOT_PREFIX));
+            }
+        }
+    }
+
+    private void addToClassLoader(File classPath) throws DuplicateRealmException, MalformedURLException {
+        ClassWorld world = new ClassWorld();
+        Thread currentThread = Thread.currentThread();
+        ClassRealm realm = world.newRealm("rapid.dependencies", currentThread.getContextClassLoader());
+        ClassRealm childRealm = realm.createChildRealm("unpacked");
+
+        classPath.mkdirs();
+        URL url = classPath.toURI().toURL();
+        childRealm.addURL(url);
+        currentThread.setContextClassLoader(childRealm);
+    }
+
+}

--- a/plugin/src/main/java/com/packleader/rapid/plugin/RapidMojo.java
+++ b/plugin/src/main/java/com/packleader/rapid/plugin/RapidMojo.java
@@ -54,6 +54,9 @@ public class RapidMojo extends AbstractMojo {
     @Component
     private DefaultValueProvider defaultValueProvider;
 
+    @Component
+    private RapidDependencyHelper rapidDependencyHelper;
+
     private ModelMapper modelMapper;
 
     public RapidMojo() {
@@ -67,6 +70,8 @@ public class RapidMojo extends AbstractMojo {
             getLog().info("<skip> parameter was set to true.  Skipping plugin.");
             return;
         }
+
+        rapidDependencyHelper.unpackDependencies();
 
         createOutputDirectory();
 

--- a/plugin/src/main/java/com/packleader/rapid/plugin/ZipFileHelper.java
+++ b/plugin/src/main/java/com/packleader/rapid/plugin/ZipFileHelper.java
@@ -1,0 +1,68 @@
+package com.packleader.rapid.plugin;
+
+import org.codehaus.plexus.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+@Component(role = ZipFileHelper.class)
+public class ZipFileHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZipFileHelper.class);
+
+    public void unpack(File source, File destinationFile, Predicate<? super ZipEntry> filter) throws IOException {
+        ZipFile zipFile = new ZipFile(source);
+        zipFile.stream()
+                .filter(filter)
+                .sorted(Comparator.comparingInt(e -> e.getName().length()))
+                .forEachOrdered(e -> unpackEntry(zipFile, e, destinationFile));
+        zipFile.close();
+    }
+
+    private void unpackEntry(ZipFile zipFile, ZipEntry zipEntry, File destinationFile) {
+        Optional<File> destination = newFile(destinationFile, zipEntry);
+        destination.ifPresent(f -> unpackFile(zipFile, zipEntry, f));
+    }
+
+    private Optional<File> newFile(File destinationDir, ZipEntry zipEntry) {
+        String zipFile = zipEntry.getName();
+        File destFile = new File(destinationDir, zipFile);
+
+        try {
+            String destDirPath = destinationDir.getCanonicalPath();
+            String destFilePath = destFile.getCanonicalPath();
+
+            if (!destFilePath.startsWith(destDirPath + File.separator)) {
+                throw new IOException("Entry is outside of the target dir");
+            }
+        } catch (IOException ex) {
+            LOGGER.warn("Skipping {}. Reason: {}", zipEntry, ex.getMessage());
+            destFile = null;
+        }
+
+        return Optional.ofNullable(destFile);
+    }
+
+    private void unpackFile(ZipFile zipFile, ZipEntry zipEntry, File destinationFile) {
+        if (zipEntry.isDirectory()) {
+            destinationFile.mkdirs();
+        }
+        else {
+            try(InputStream is = zipFile.getInputStream(zipEntry)) {
+                Files.copy(is, destinationFile.toPath());
+            } catch (IOException ex) {
+                LOGGER.warn("Failed to extract {}. Reason: {}", zipEntry, ex.getMessage());
+            }
+        }
+    }
+
+}

--- a/plugin/src/test/java/com/packleader/rapid/plugin/RapidComponentConfiguratorTest.java
+++ b/plugin/src/test/java/com/packleader/rapid/plugin/RapidComponentConfiguratorTest.java
@@ -24,10 +24,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.*;
-import static org.testng.Assert.*;
 
 @PrepareForTest(RapidComponentConfigurator.class)
 public class RapidComponentConfiguratorTest extends BaseTest {
@@ -124,7 +124,7 @@ public class RapidComponentConfiguratorTest extends BaseTest {
 
         rapidComponentConfigurator.configureComponent(componentMock, configurationMock, expressionEvaluatorMock, containerRealmMock, listenerMock);
 
-        Mockito.verify(fileMock, times(0)).toURI();
-        Mockito.verify(containerRealmMock, times(0)).addConstituent(any());
+        Mockito.verify(fileMock, never()).toURI();
+        Mockito.verify(containerRealmMock, never()).addConstituent(any());
     }
 }

--- a/plugin/src/test/java/com/packleader/rapid/plugin/RapidDependencyHelperTest.java
+++ b/plugin/src/test/java/com/packleader/rapid/plugin/RapidDependencyHelperTest.java
@@ -1,0 +1,94 @@
+package com.packleader.rapid.plugin;
+
+import com.packleader.rapid.BaseTest;
+import org.apache.maven.model.Build;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.powermock.api.mockito.PowerMockito.*;
+
+@PrepareForTest(RapidDependencyHelper.class)
+public class RapidDependencyHelperTest extends BaseTest {
+
+    @Mock
+    private MavenProject mavenProjectMock;
+
+    @Mock
+    private ZipFileHelper zipFileHelperMock;
+
+    @InjectMocks
+    private RapidDependencyHelper rapidDependencyHelper;
+
+    private static final String SPRING_BOOT_PREFIX = "BOOT-INF/classes/";
+
+    @Test
+    public void testUnpackDependencies() throws Exception {
+        mockStatic(URLDecoder.class);
+        mockStatic(Thread.class);
+        final String buildDirectory = "build-dir";
+        final String dependenciesDirectory = buildDirectory + "/unpacked-dependencies";
+        final String dependency1 = "dep1.jar";
+        final String dependency2 = "dep12jar";
+        final String dependencyUrl1 = "file://dep1.jar";
+        final String dependencyUrl2 = "file://dep12jar";
+        final String charset = StandardCharsets.UTF_8.name();
+        List<String> dependencies = Arrays.asList(dependency1, dependency2);
+
+        Build buildMock = mock(Build.class);
+        File destDirMock = mock(File.class);
+        File dependencyFileMock1 = mock(File.class);
+        File dependencyFileMock2 = mock(File.class);
+        ClassWorld classWorldMock = mock(ClassWorld.class);
+        Thread currentThreadMock = mock(Thread.class);
+        File classDirMock = mock(File.class);
+        URI classDirUriMock = mock(URI.class);
+        URL classDirUrlMock = mock(URL.class);
+        ClassLoader classLoaderMock = mock(ClassLoader.class);
+        ClassRealm realmMock = mock(ClassRealm.class);
+        ClassRealm childRealmMock = mock(ClassRealm.class);
+
+        when(mavenProjectMock.getBuild()).thenReturn(buildMock);
+        when(buildMock.getDirectory()).thenReturn(buildDirectory);
+        whenNew(File.class).withArguments(dependenciesDirectory).thenReturn(destDirMock);
+        when(mavenProjectMock.getCompileClasspathElements()).thenReturn(dependencies);
+        when(URLDecoder.decode(dependency1, charset)).thenReturn(dependencyUrl1);
+        when(URLDecoder.decode(dependency2, charset)).thenReturn(dependencyUrl2);
+        whenNew(File.class).withArguments(dependencyUrl1).thenReturn(dependencyFileMock1);
+        whenNew(File.class).withArguments(dependencyUrl2).thenReturn(dependencyFileMock2);
+        when(dependencyFileMock1.isFile()).thenReturn(false);
+        when(dependencyFileMock2.isFile()).thenReturn(true);
+        whenNew(File.class).withArguments(destDirMock, SPRING_BOOT_PREFIX).thenReturn(classDirMock);
+        when(classDirMock.toURI()).thenReturn(classDirUriMock);
+        when(classDirUriMock.toURL()).thenReturn(classDirUrlMock);
+        whenNew(ClassWorld.class).withNoArguments().thenReturn(classWorldMock);
+        when(Thread.currentThread()).thenReturn(currentThreadMock);
+        when(currentThreadMock.getContextClassLoader()).thenReturn(classLoaderMock);
+        when(classWorldMock.newRealm("rapid.dependencies", classLoaderMock)).thenReturn(realmMock);
+        when(realmMock.createChildRealm("unpacked")).thenReturn(childRealmMock);
+
+        rapidDependencyHelper.unpackDependencies();
+
+        Mockito.verify(zipFileHelperMock, never()).unpack(eq(dependencyFileMock1), eq(destDirMock), any());
+        Mockito.verify(zipFileHelperMock).unpack(eq(dependencyFileMock2), eq(destDirMock), any());
+        Mockito.verify(childRealmMock).addURL(classDirUrlMock);
+        Mockito.verify(currentThreadMock).setContextClassLoader(childRealmMock);
+    }
+
+}

--- a/plugin/src/test/java/com/packleader/rapid/plugin/RapidMojoTest.java
+++ b/plugin/src/test/java/com/packleader/rapid/plugin/RapidMojoTest.java
@@ -29,7 +29,6 @@ import static org.testng.Assert.assertSame;
 @PrepareForTest(RapidMojo.class)
 public class RapidMojoTest extends BaseTest {
 
-
     @Mock
     private MavenProject mavenProjectMock;
 
@@ -46,6 +45,9 @@ public class RapidMojoTest extends BaseTest {
     private DefaultValueProvider defaultValueProviderMock;
 
     @Mock
+    private RapidDependencyHelper rapidDependencyHelperMock;
+
+    @Mock
     private ModelMapper modelMapperMock;
 
     @Mock
@@ -55,7 +57,7 @@ public class RapidMojoTest extends BaseTest {
     private CodeGeneratorConfig codeGeneratorConfigMock;
 
     @InjectMocks
-    private RapidMojo rapidMojo = new RapidMojo();
+    private RapidMojo rapidMojo;
 
     @BeforeMethod
     @Override
@@ -90,6 +92,7 @@ public class RapidMojoTest extends BaseTest {
 
         testExecute(generatedSourcesDirectory, outputDir);
 
+        Mockito.verify(rapidDependencyHelperMock).unpackDependencies();
         Mockito.verify(mavenProjectMock).addCompileSourceRoot(sourceJavaFolder);
         Mockito.verify(fileMock).mkdirs();
     }

--- a/plugin/src/test/java/com/packleader/rapid/plugin/ZipFileHelperTest.java
+++ b/plugin/src/test/java/com/packleader/rapid/plugin/ZipFileHelperTest.java
@@ -1,0 +1,91 @@
+package com.packleader.rapid.plugin;
+
+import com.packleader.rapid.BaseTest;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.mockito.Mockito.inOrder;
+import static org.powermock.api.mockito.PowerMockito.*;
+import static org.testng.Assert.assertSame;
+
+@PrepareForTest({ZipFileHelper.class})
+public class ZipFileHelperTest extends BaseTest {
+
+    @InjectMocks
+    private ZipFileHelper zipFileHelper;
+
+    @Test
+    public void testUnpackDependencies() throws Exception {
+        mockStatic(Files.class);
+        final String zipEntryName1 = "skipMe";
+        final String zipEntryName2 = "thisIsAReallyLongName";
+        final String zipEntryName3 = "shortName";
+        final String zipEntryName4 = "invalidPath";
+        final String destinationFilePath = "destinationDirectory";
+        File sourceMock = mock(File.class);
+        File destinationFileMock = mock(File.class);
+        ZipFile zipFileMock = mock(ZipFile.class);
+        ZipEntry zipEntryMock1 = mockZipEntry(zipEntryName1, false);
+        ZipEntry zipEntryMock2 = mockZipEntry(zipEntryName2, true);
+        ZipEntry zipEntryMock3 = mockZipEntry(zipEntryName3, false);
+        ZipEntry zipEntryMock4 = mockZipEntry(zipEntryName4, false);
+        Stream zipEntryStream = Stream.of(zipEntryMock1, zipEntryMock2, zipEntryMock3, zipEntryMock4);
+        File destFileMock2 = mockFile(destinationFilePath, "destFilePath2");
+        File destFileMock3 = mockFile(destinationFilePath, "destFilePath3");
+        File destFileMock4 = mockFile("invalidPath", "destFilePath4");
+        InputStream inputStreamMock = mock(InputStream.class);
+        Path destinationPathMock = mock(Path.class);
+        ArgumentCaptor<InputStream> inputStreamCaptor = ArgumentCaptor.forClass(InputStream.class);
+        ArgumentCaptor<Path> pathCaptor = ArgumentCaptor.forClass(Path.class);
+
+        whenNew(ZipFile.class).withArguments(sourceMock).thenReturn(zipFileMock);
+        when(zipFileMock.stream()).thenReturn(zipEntryStream);
+        whenNew(File.class).withArguments(destinationFileMock, zipEntryName2).thenReturn(destFileMock2);
+        whenNew(File.class).withArguments(destinationFileMock, zipEntryName3).thenReturn(destFileMock3);
+        whenNew(File.class).withArguments(destinationFileMock, zipEntryName4).thenReturn(destFileMock4);
+        when(destinationFileMock.getCanonicalPath()).thenReturn(destinationFilePath);
+        when(zipFileMock.getInputStream(zipEntryMock3)).thenReturn(inputStreamMock);
+        when(destFileMock3.toPath()).thenReturn(destinationPathMock);
+        when(Files.copy(inputStreamCaptor.capture(), pathCaptor.capture())).thenReturn(0l);
+
+        zipFileHelper.unpack(sourceMock, destinationFileMock, e -> e != zipEntryMock1);
+
+        Mockito.verify(zipEntryMock1, Mockito.never()).isDirectory();
+        Mockito.verify(destFileMock2).mkdirs();
+        assertSame(inputStreamCaptor.getValue(), inputStreamMock);
+        assertSame(pathCaptor.getValue(), destinationPathMock);
+        Mockito.verify(zipEntryMock4, Mockito.never()).isDirectory();
+
+        InOrder inOrder = inOrder(zipEntryMock3, zipEntryMock2);
+        inOrder.verify(zipEntryMock3).isDirectory();
+        inOrder.verify(zipEntryMock2).isDirectory();
+    }
+
+    private ZipEntry mockZipEntry(String name, boolean isDirectory) {
+        ZipEntry zipEntryMock = mock(ZipEntry.class);
+        when(zipEntryMock.getName()).thenReturn(name);
+        when(zipEntryMock.isDirectory()).thenReturn(isDirectory);
+        return zipEntryMock;
+    }
+
+    private File mockFile(String destinationFilePath, String canonicalPath) throws IOException {
+        File fileMock = mock(File.class);
+        canonicalPath = destinationFilePath + File.separator + canonicalPath;
+        when(fileMock.getCanonicalPath()).thenReturn(canonicalPath);
+        return fileMock;
+    }
+
+}


### PR DESCRIPTION
Resolves #9 by searching the dependency tree for Spring Boot runnable JARs and extracting the relevant class files.